### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -25,7 +25,10 @@ import optparse
 import re
 import sys
 
-import pkg_resources
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 try:
     from collections import OrderedDict
@@ -552,7 +555,7 @@ def main():
     """
 
     scheme_names = sorted(SCHEME.keys())
-    version_str = pkg_resources.get_distribution("ansi2html").version
+    version_str = version("ansi2html")
     parser = optparse.OptionParser(
         usage=main.__doc__, version="%%prog %s" % version_str
     )


### PR DESCRIPTION
Replaces usage of pkg_resources.get_distribution() with importlib.metadata.version().
The pkg_resources package is slated for removal as early as 2025-11-30, and this change avoids future compatibility issues while suppressing deprecation warnings.